### PR TITLE
Fix typo in lifecycle guide

### DIFF
--- a/pages/guides/lifecycle.mdx
+++ b/pages/guides/lifecycle.mdx
@@ -10,7 +10,7 @@ It starts by adding a **message value to the contract balance**. Value of incomi
 
 Then some (usually small amount) of nanotons is substracted from contract balance for storage. This means that you can't perfectly predict balance changes and have to adjust your code to this instability.
 
-Then it deploys a contract if it is not deployed yet and message contains init package. If init package is present, it would be ignored.
+Then it deploys a contract if it is not deployed yet and message contains init package. If init package isn't present, it would be ignored.
 
 ## Compute Phase
 


### PR DESCRIPTION
Not sure, but looks like there is the typo in lifecycle gude. 

As I understand If init package isn't present, deploy then would be ignored.